### PR TITLE
タグづけ機能の実装02

### DIFF
--- a/app/assets/stylesheets/items/show.css
+++ b/app/assets/stylesheets/items/show.css
@@ -208,8 +208,8 @@
   font-size: 23px;
 }
 
-#search-result{
-  width: 30%;
+#tag_search-result{
+  width: 100%;
 }
 
 .child{

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -54,7 +54,7 @@ class ItemsController < ApplicationController
     end
   end
 
-  def search
+  def tag_search
 
     # タグ入力のための記述
     return nil if params[:keyword] == ""

--- a/app/javascript/tag.js
+++ b/app/javascript/tag.js
@@ -5,11 +5,11 @@ document.addEventListener("DOMContentLoaded", () => {
     inputElement.addEventListener("input", () => {
       const keyword = document.getElementById("item_form_tag_name").value;
       const XHR = new XMLHttpRequest();
-      XHR.open("GET", `/items/search/?keyword=${keyword}`, true);
+      XHR.open("GET", `/items/tag_search/?keyword=${keyword}`, true);
       XHR.responseType = "json";
       XHR.send();
       XHR.onload = () => {
-        const searchResult = document.getElementById("search-result");
+        const searchResult = document.getElementById("tag_search-result");
         searchResult.innerHTML = "";
         if (XHR.response) {
           const tagName = XHR.response.keyword;

--- a/app/models/item_form.rb
+++ b/app/models/item_form.rb
@@ -17,7 +17,7 @@ class ItemForm
       validates :category_id, :condition_id, :cost_id, :prefecture_id, :scheduled_day_id,
                 numericality: { other_than: 1, message: "can't be blank" }
     end
-    validates :tag_name,  uniqueness: true, length: { maximum: 18 }
+    validates :tag_name, length: { maximum: 18 }
 
   
     def save

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,5 +1,5 @@
 class Tag < ApplicationRecord
   has_many :item_tag_relations
   has_many :items, through: :item_tag_relations
-  validates :tag_name,  uniqueness: true
+  validates :tag_name, uniqueness: {case_sensitive: true}, presence: true
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,5 @@
 class Tag < ApplicationRecord
   has_many :item_tag_relations
   has_many :items, through: :item_tag_relations
+  validates :tag_name,  uniqueness: true
 end

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -50,7 +50,7 @@
           <span class="indispensable">任意</span>
         </div>
         <%= f.text_field :tag_name, class:"items-text", placeholder:"タグ（任意 18文字まで)", maxlength:"18" %>
-        <div id="search-result"></div>
+        <div id="tag_search-result"></div>
         <div class="weight-bold-text">
           カテゴリー
           <span class="indispensable">必須</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   root to: "items#index"
   resources :items do
     collection do
-      get 'search'
+      get 'tag_search'
       get 'item_search'
     end
     resources :orders, only: [:index, :create]

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :tag do
-    
+    tag_name    { 'レア' }
   end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,5 +1,29 @@
 require 'rails_helper'
 
 RSpec.describe Tag, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  before do
+    @tag = FactoryBot.build(:tag)
+  end
+
+  describe 'タグ新規登録' do
+    context '新規登録できるとき' do
+      it 'タグが存在すれば登録できる' do
+        expect(@tag).to be_valid
+      end
+    end
+    context '新規登録できないとき' do
+      it 'タグが空では登録できない' do
+        @tag.tag_name = ''
+        @tag.valid?
+        expect(@tag.errors.full_messages).to include("Tag name can't be blank")
+      end
+      it '重複したタグが存在する場合は登録できない' do
+        @tag.save
+        another_tag = FactoryBot.build(:tag)
+        another_tag.tag_name = @tag.tag_name
+        another_tag.valid?
+        expect(another_tag.errors.full_messages).to include('Tag name has already been taken')
+      end
+    end
+  end
 end


### PR DESCRIPTION
# What
- コントローラーのアクション名をtag_searchに変更（商品検索機能を実装したのでアクション名searchから変更）
- 単体テストの実施
# Why
- コードの可読性を上げるため
- 単体テスト未実施だったため